### PR TITLE
Update and prepare for 5.0.0 release

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -40,13 +40,6 @@ tags:
   - aws
   - lambda
 
-# Collections that this collection requires to be installed for it to be usable. The key of the dict is the
-# collection label 'namespace.name'. The value is a version range
-# L(specifiers,https://python-semanticversion.readthedocs.io/en/latest/#requirement-specification). Multiple version
-# range specifiers can be set and are separated by ','
-dependencies:
-  amazon.aws: '>=7.0.0,<8.0.0'
-
 # The URL of the originating SCM repository
 repository: https://github.com/mattclay/ansible-collection-aws
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ namespace: mattclay
 name: aws
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 4.1.0
+version: 5.0.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,17 +1,1 @@
 requires_ansible: '>=2.11'
-action_groups:
-  common:
-    # this collection
-    - apigateway
-    - aws_account_facts
-    - aws_availability_zone_facts
-    - cloudwatch_event
-    - lambda
-    - lambda_alias
-    - lambda_layer
-    - lambda_package
-    - lambda_policy
-    - sqs_event
-    - sqs_fifo_queue
-    # external collections
-    - amazon.aws.iam_role

--- a/plugins/filter/dictfilter.py
+++ b/plugins/filter/dictfilter.py
@@ -1,11 +1,14 @@
 # Copyright (C) 2016 Matt Clay <matt@mystile.com>
 # GNU General Public License v3.0+ (see LICENSE.md or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from __future__ import annotations
+
+
 def dictfilter(item, keys):
     return dict((k, item[k]) for k in item if k in keys)
 
 
-class FilterModule(object):
+class FilterModule:
     def filters(self):
         return dict(
             dictfilter=dictfilter,

--- a/plugins/filter/ec2_az_vpc_route_tables_subnets.py
+++ b/plugins/filter/ec2_az_vpc_route_tables_subnets.py
@@ -1,6 +1,8 @@
 # Copyright (C) 2016 Matt Clay <matt@mystile.com>
 # GNU General Public License v3.0+ (see LICENSE.md or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from __future__ import annotations
+
 
 def ec2_az_vpc_route_tables_subnets(zones, subnet):
     return [map_zone_to_subnet(z, subnet) for z in zones]
@@ -11,7 +13,7 @@ def map_zone_to_subnet(zone, subnet):
     return subnet % position
 
 
-class FilterModule(object):
+class FilterModule:
     def filters(self):
         return dict(
             ec2_az_vpc_route_tables_subnets=ec2_az_vpc_route_tables_subnets,

--- a/plugins/filter/ec2_az_vpc_subnets.py
+++ b/plugins/filter/ec2_az_vpc_subnets.py
@@ -1,6 +1,9 @@
 # Copyright (C) 2016 Matt Clay <matt@mystile.com>
 # GNU General Public License v3.0+ (see LICENSE.md or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from __future__ import annotations
+
+
 def ec2_az_vpc_subnets(zones, subnet, name):
     return [dict(
         cidr=map_zone_to_subnet(z, subnet),
@@ -16,7 +19,7 @@ def map_zone_to_subnet(zone, subnet):
     return subnet % position
 
 
-class FilterModule(object):
+class FilterModule:
     def filters(self):
         return dict(
             ec2_az_vpc_subnets=ec2_az_vpc_subnets,

--- a/plugins/filter/ec2_az_vpc_subnets.yml
+++ b/plugins/filter/ec2_az_vpc_subnets.yml
@@ -2,7 +2,7 @@ DOCUMENTATION:
   name: ec2_az_vpc_subnets
   short_description: generate a list of availability zones and subnets
   description:
-    - Use the input zones dictionary, provided subnet format string and tag name to build a list of availiability zones with subnets.
+    - Use the input zones dictionary, provided subnet format string and tag name to build a list of availability zones with subnets.
   positional: _input, subnet, name
   options:
     _input:

--- a/plugins/filter/map_format.py
+++ b/plugins/filter/map_format.py
@@ -1,6 +1,9 @@
 # Copyright (C) 2017 Matt Clay <matt@mystile.com>
 # GNU General Public License v3.0+ (see LICENSE.md or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from __future__ import annotations
+
+
 def map_format(item, fmt, *args, **kwargs):
     d = {}
     d.update(item)
@@ -8,7 +11,7 @@ def map_format(item, fmt, *args, **kwargs):
     return fmt.format(*args, **d)
 
 
-class FilterModule(object):
+class FilterModule:
     def filters(self):
         return dict(
             map_format=map_format,

--- a/plugins/module_utils/aws.py
+++ b/plugins/module_utils/aws.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import functools
+import typing as t
+
+if t.TYPE_CHECKING:
+    import boto3 as t_boto3
+
+    from types_boto3_apigateway import APIGatewayClient
+    from types_boto3_ec2 import EC2Client
+    from types_boto3_events import EventBridgeClient
+    from types_boto3_lambda import LambdaClient
+    from types_boto3_sqs.service_resource import SQSServiceResource
+    from types_boto3_sts import STSClient
+
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+class AwsModule(AnsibleModule):
+    @functools.cached_property
+    def client(self) -> AwsClient:
+        return AwsClient(self)
+
+    @functools.cached_property
+    def resource(self) -> AwsResource:
+        return AwsResource(self)
+
+    @functools.cached_property
+    def account_id(self) -> str:
+        return self.client.sts.get_caller_identity()["Account"]
+
+    @functools.cached_property
+    def region(self) -> str:
+        return self.session.region_name
+
+    @functools.cached_property
+    def session(self) -> t_boto3.Session:
+        import boto3
+
+        return boto3.Session()
+
+
+class AwsClient:
+    def __init__(self, module: AwsModule) -> None:
+        self._module = module
+
+    def _client(self, service_name: str) -> t.Any:
+        return self._module.session.client(service_name)
+
+    @functools.cached_property
+    def apigateway(self) -> APIGatewayClient:
+        return self._client('apigateway')
+
+    @functools.cached_property
+    def awslambda(self) -> LambdaClient:
+        return self._client('lambda')
+
+    @functools.cached_property
+    def ec2(self) -> EC2Client:
+        return self._client('ec2')
+
+    @functools.cached_property
+    def events(self) -> EventBridgeClient:
+        return self._client('events')
+
+    @functools.cached_property
+    def sts(self) -> STSClient:
+        return self._client('sts')
+
+
+class AwsResource:
+    def __init__(self, module: AwsModule) -> None:
+        self._module = module
+
+    def _resource(self, service_name: str) -> t.Any:
+        return self._module.session.resource(service_name)
+
+    @functools.cached_property
+    def sqs(self) -> SQSServiceResource:
+        return self._resource('sqs')

--- a/plugins/modules/apigateway.py
+++ b/plugins/modules/apigateway.py
@@ -2,6 +2,9 @@
 # Copyright (C) 2016 Matt Clay <matt@mystile.com>
 # GNU General Public License v3.0+ (see LICENSE.md or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from __future__ import annotations
+
+
 DOCUMENTATION = '''
 ---
 module: apigateway

--- a/plugins/modules/apigateway.py
+++ b/plugins/modules/apigateway.py
@@ -15,7 +15,6 @@ author:
     - Matt Clay (@mattclay) <matt@mystile.com>
 requirements:
     - boto3
-    - botocore
 options:
     state:
         description:
@@ -71,9 +70,6 @@ options:
             - Stage variables to include in the deployment.
         type: dict
         default: {}
-extends_documentation_fragment:
-    - amazon.aws.common.modules
-    - amazon.aws.region.modules
 '''
 
 EXAMPLES = '''
@@ -89,27 +85,11 @@ apigateway:
 
 import json
 
-try:
-    import botocore
-    import botocore.exceptions
-except ImportError:
-    botocore = None
-
-from ansible.module_utils.basic import (
-    AnsibleModule,
-)
-
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (
-    boto3_conn,
-    ec2_argument_spec,
-    get_aws_connection_info,
-    HAS_BOTO3,
-)
+from ..module_utils.aws import AwsModule
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         state=dict(required=False, default='present', type='str', choices=['present', 'absent']),
         swagger=dict(required=True, type='str'),
         api_name=dict(required=False, default=None, type='str'),
@@ -119,9 +99,9 @@ def main():
         mode=dict(required=False, default='merge', type='str', choices=['merge', 'overwrite']),
         fail_on_warnings=dict(required=False, default=True, type='bool'),
         stage_variables=dict(required=False, default={}, type='dict'),
-    ))
+    )
 
-    module = AnsibleModule(
+    module = AwsModule(
         argument_spec=argument_spec,
         supports_check_mode=True,
     )
@@ -137,21 +117,13 @@ def main():
 
 
 class ApiGatewayModule:
-    def __init__(self, module, check_mode, params):
+    def __init__(self, module: AwsModule, check_mode: bool, params: dict) -> None:
         self.module = module
         self.check_mode = check_mode
         self.params = params
-        self.ag = None
+        self.ag = module.client.apigateway
 
     def run(self):
-        if not HAS_BOTO3:
-            return 'the boto3 python module is required to use this module', None, None
-
-        region, ec2_url, aws_connect_kwargs = get_aws_connection_info(self.module, boto3=True)
-
-        self.ag = boto3_conn(self.module, conn_type='client', resource='apigateway', region=region, endpoint=ec2_url,
-                             **aws_connect_kwargs)
-
         choice_map = dict(
             present=self.api_present,
             absent=self.api_absent,
@@ -254,10 +226,8 @@ class ApiGatewayModule:
                 exportType='swagger',
                 parameters={'extensions': 'integrations'},
             )['body'].read()
-        except botocore.exceptions.ClientError as ex:
-            if ex.response['Error']['Code'] == 'NotFoundException':
-                return None
-            raise
+        except self.ag.exceptions.NotFoundException:
+            return None
 
 
 if __name__ == '__main__':

--- a/plugins/modules/aws_account_facts.py
+++ b/plugins/modules/aws_account_facts.py
@@ -15,32 +15,19 @@ author:
     - Matt Clay (@mattclay) <matt@mystile.com>
 requirements:
     - boto3
-    - botocore
-extends_documentation_fragment:
-    - amazon.aws.common.modules
-    - amazon.aws.region.modules
 '''
 
 EXAMPLES = '''
 aws_account_facts:
 '''
 
-from ansible.module_utils.basic import (
-    AnsibleModule,
-)
-
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (
-    boto3_conn,
-    ec2_argument_spec,
-    get_aws_connection_info,
-    HAS_BOTO3,
-)
+from ..module_utils.aws import AwsModule
 
 
 def main():
-    argument_spec = ec2_argument_spec()
+    argument_spec = {}
 
-    module = AnsibleModule(
+    module = AwsModule(
         argument_spec=argument_spec,
         supports_check_mode=True,
     )
@@ -56,26 +43,14 @@ def main():
 
 
 class AwsAccountFactsModule:
-    def __init__(self, module, check_mode, params):
+    def __init__(self, module: AwsModule, check_mode: bool, params: dict) -> None:
         self.module = module
         self.check_mode = check_mode
         self.params = params
 
     def run(self):
-        if not HAS_BOTO3:
-            return 'the boto3 python module is required to use this module', None
-
-        region, endpoint, aws_connect_kwargs = get_aws_connection_info(self.module, boto3=True)
-
-        sts = boto3_conn(self.module, conn_type='client', resource='sts', region=region, endpoint=endpoint,
-                         **aws_connect_kwargs)
-
-        caller_identity = sts.get_caller_identity()
-        caller_arn = caller_identity['Arn']
-        caller_account_id = caller_arn.split(':')[4]
-
         facts = dict(
-            aws_account_id=caller_account_id,
+            aws_account_id=self.module.account_id,
         )
 
         return None, facts

--- a/plugins/modules/aws_account_facts.py
+++ b/plugins/modules/aws_account_facts.py
@@ -2,6 +2,9 @@
 # Copyright (C) 2016 Matt Clay <matt@mystile.com>
 # GNU General Public License v3.0+ (see LICENSE.md or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from __future__ import annotations
+
+
 DOCUMENTATION = '''
 ---
 module: aws_account_facts

--- a/plugins/modules/aws_availability_zone_facts.py
+++ b/plugins/modules/aws_availability_zone_facts.py
@@ -2,6 +2,9 @@
 # Copyright (C) 2016 Matt Clay <matt@mystile.com>
 # GNU General Public License v3.0+ (see LICENSE.md or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from __future__ import annotations
+
+
 DOCUMENTATION = '''
 ---
 module: aws_availability_zone_facts

--- a/plugins/modules/aws_availability_zone_facts.py
+++ b/plugins/modules/aws_availability_zone_facts.py
@@ -15,33 +15,21 @@ author:
     - Matt Clay (@mattclay) <matt@mystile.com>
 requirements:
     - boto3
-    - botocore
-extends_documentation_fragment:
-    - amazon.aws.common.modules
-    - amazon.aws.region.modules
 '''
 
 EXAMPLES = '''
 aws_availability_zone_facts:
 '''
 
-from ansible.module_utils.basic import (
-    AnsibleModule,
-)
+from ..module_utils.aws import AwsModule
 
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (
-    boto3_conn,
-    camel_dict_to_snake_dict,
-    ec2_argument_spec,
-    get_aws_connection_info,
-    HAS_BOTO3,
-)
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 
 
 def main():
-    argument_spec = ec2_argument_spec()
+    argument_spec = {}
 
-    module = AnsibleModule(
+    module = AwsModule(
         argument_spec=argument_spec,
         supports_check_mode=True,
     )
@@ -57,21 +45,13 @@ def main():
 
 
 class AwsAvailabilityZoneFactsModule:
-    def __init__(self, module, check_mode, params):
+    def __init__(self, module: AwsModule, check_mode: bool, params: dict) -> None:
         self.module = module
         self.check_mode = check_mode
         self.params = params
-        self.ec2 = None
+        self.ec2 = module.client.ec2
 
     def run(self):
-        if not HAS_BOTO3:
-            return 'the boto3 python module is required to use this module', {}
-
-        region, ec2_url, aws_connect_kwargs = get_aws_connection_info(self.module, boto3=True)
-
-        self.ec2 = boto3_conn(self.module, conn_type='client', resource='ec2', region=region, endpoint=ec2_url,
-                              **aws_connect_kwargs)
-
         zones = self.ec2.describe_availability_zones()['AvailabilityZones']
         zones = [camel_dict_to_snake_dict(z) for z in zones]
 

--- a/plugins/modules/cloudwatch_event.py
+++ b/plugins/modules/cloudwatch_event.py
@@ -15,7 +15,6 @@ author:
     - Matt Clay (@mattclay) <matt@mystile.com>
 requirements:
     - boto3
-    - botocore
 options:
     rule_name:
         description:
@@ -48,9 +47,6 @@ options:
             - absent
         default: enabled
         type: str
-extends_documentation_fragment:
-    - amazon.aws.common.modules
-    - amazon.aws.region.modules
 '''
 
 EXAMPLES = '''
@@ -63,35 +59,19 @@ cloudwatch_event:
 
 import uuid
 
-try:
-    import botocore
-    import botocore.exceptions
-except ImportError:
-    botocore = None
-
-from ansible.module_utils.basic import (
-    AnsibleModule,
-)
-
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (
-    boto3_conn,
-    ec2_argument_spec,
-    get_aws_connection_info,
-    HAS_BOTO3,
-)
+from ..module_utils.aws import AwsModule
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         rule_name=dict(required=True, type='str'),
         function_name=dict(required=True, type='str'),
         schedule_expression=dict(required=True, type='str'),
         description=dict(required=False, default='', type='str'),
         state=dict(required=False, default='enabled', type='str', choices=['enabled', 'disabled', 'absent']),
-    ))
+    )
 
-    module = AnsibleModule(
+    module = AwsModule(
         argument_spec=argument_spec,
         supports_check_mode=True,
     )
@@ -107,30 +87,18 @@ def main():
 
 
 class EventsModule:
-    def __init__(self, module, check_mode, params):
+    def __init__(self, module: AwsModule, check_mode: bool, params: dict) -> None:
         self.module = module
         self.check_mode = check_mode
         self.params = params
-        self.events = None
-        self.iam = None
-        self.account_id = None
+        self.events = module.client.events
 
     def run(self):
-        if not HAS_BOTO3:
-            return 'the boto3 python module is required to use this module', None, None
-
-        region, ec2_url, aws_connect_kwargs = get_aws_connection_info(self.module, boto3=True)
-
-        self.events = boto3_conn(self.module, conn_type='client', resource='events', region=region, endpoint=ec2_url,
-                                 **aws_connect_kwargs)
-
-        self.iam = boto3_conn(self.module, conn_type='resource', resource='iam', region=region, endpoint=ec2_url,
-                              **aws_connect_kwargs)
-
-        self.account_id = self.iam.CurrentUser().arn.split(':')[4]
+        account_id = self.module.account_id
+        region = self.module.region
 
         if not self.params['function_name'].startswith('arn:aws:iam:'):
-            self.params['function_name'] = 'arn:aws:lambda:%s:%s:function:%s' % (region, self.account_id, self.params['function_name'])
+            self.params['function_name'] = 'arn:aws:lambda:%s:%s:function:%s' % (region, account_id, self.params['function_name'])
 
         choice_map = dict(
             enabled=self.function_present,
@@ -154,10 +122,8 @@ class EventsModule:
     def get_rule(self):
         try:
             return self.events.describe_rule(Name=self.params['rule_name'])
-        except botocore.exceptions.ClientError as ex:
-            if ex.response['Error']['Code'] == 'ResourceNotFoundException':
-                return None
-            raise
+        except self.events.exceptions.ResourceNotFoundException:
+            return None
 
     def put_rule(self, remote_rule=None):
         local_rule = dict(
@@ -175,7 +141,7 @@ class EventsModule:
         else:
             rule_changed = any(k for k in local_rule if local_rule[k] != remote_rule.get(k, ''))
             targets = self.events.list_targets_by_rule(Rule=self.params['rule_name'])['Targets']
-            targets = [t for t in targets if t['Arn'] == self.params['function_name']]
+            targets = [target for target in targets if target['Arn'] == self.params['function_name']]
             target_changed = not bool(targets)
             data.update(remote_rule)
 

--- a/plugins/modules/cloudwatch_event.py
+++ b/plugins/modules/cloudwatch_event.py
@@ -2,6 +2,9 @@
 # Copyright (C) 2016 Matt Clay <matt@mystile.com>
 # GNU General Public License v3.0+ (see LICENSE.md or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from __future__ import annotations
+
+
 DOCUMENTATION = '''
 ---
 module: cloudwatch_event

--- a/plugins/modules/lambda.py
+++ b/plugins/modules/lambda.py
@@ -15,7 +15,6 @@ author:
     - Matt Clay (@mattclay) <matt@mystile.com>
 requirements:
     - boto3
-    - botocore
 options:
     function_name:
         description:
@@ -147,10 +146,6 @@ options:
             - debug
             - info
             - warn
-
-extends_documentation_fragment:
-    - amazon.aws.common.modules
-    - amazon.aws.region.modules
 '''
 
 EXAMPLES = '''
@@ -176,27 +171,11 @@ import os
 import zipfile
 import time
 
-try:
-    import botocore
-    import botocore.exceptions
-except ImportError:
-    botocore = None
-
-from ansible.module_utils.basic import (
-    AnsibleModule,
-)
-
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (
-    boto3_conn,
-    ec2_argument_spec,
-    get_aws_connection_info,
-    HAS_BOTO3,
-)
+from ..module_utils.aws import AwsModule
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         function_name=dict(required=True, type='str', aliases=['name']),
         runtime=dict(required=True, type='str'),
         role=dict(required=True, type='str'),
@@ -219,9 +198,9 @@ def main():
         log_group=dict(required=False, default=None, type='str'),
         application_log_level=dict(required=False, default='info', type='str', choices=['trace', 'debug', 'info', 'warn', 'error', 'fatal']),
         system_log_level=dict(required=False, default='info', type='str', choices=['debug', 'info', 'warn']),
-    ))
+    )
 
-    module = AnsibleModule(
+    module = AwsModule(
         argument_spec=argument_spec,
         supports_check_mode=True,
         mutually_exclusive=[
@@ -245,29 +224,16 @@ def main():
 
 
 class LambdaModule:
-    def __init__(self, module, check_mode, params):
+    def __init__(self, module: AwsModule, check_mode: bool, params: dict) -> None:
         self.module = module
         self.check_mode = check_mode
         self.params = params
         self.package = None
-        self.al = None
-        self.iam = None
+        self.al = module.client.awslambda
 
     def run(self):
-        if not HAS_BOTO3:
-            return 'the boto3 python module is required to use this module', None, None
-
-        region, ec2_url, aws_connect_kwargs = get_aws_connection_info(self.module, boto3=True)
-
-        self.al = boto3_conn(self.module, conn_type='client', resource='lambda', region=region, endpoint=ec2_url, **aws_connect_kwargs)
-
         if not self.params['role'].startswith('arn:aws:iam:'):
-            sts = boto3_conn(self.module, conn_type='client', resource='sts', region=region, endpoint=ec2_url, **aws_connect_kwargs)
-
-            caller_identity = sts.get_caller_identity()
-            caller_arn = caller_identity['Arn']
-
-            account_id = caller_arn.split(':')[4]
+            account_id = self.module.account_id
 
             self.params['role'] = 'arn:aws:iam::%s:role/%s' % (account_id, self.params['role'])
 
@@ -305,10 +271,8 @@ class LambdaModule:
                 FunctionName=self.params['function_name'],
                 **args
             )
-        except botocore.exceptions.ClientError as ex:
-            if ex.response['Error']['Code'] == 'ResourceNotFoundException':
-                return None
-            raise
+        except self.al.exceptions.ResourceNotFoundException:
+            return None
 
         if result.get('Layers'):
             result['Layers'] = [layer['Arn'] for layer in result['Layers']]

--- a/plugins/modules/lambda.py
+++ b/plugins/modules/lambda.py
@@ -2,6 +2,9 @@
 # Copyright (C) 2016 Matt Clay <matt@mystile.com>
 # GNU General Public License v3.0+ (see LICENSE.md or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from __future__ import annotations
+
+
 DOCUMENTATION = '''
 ---
 module: lambda

--- a/plugins/modules/lambda.py
+++ b/plugins/modules/lambda.py
@@ -288,10 +288,9 @@ class LambdaModule:
 
         if self.params['local_path'] is not None:
             local_path = self.params['local_path']
+            local_contents = ''
 
-            if self.check_mode and not os.path.exists(local_path):
-                local_contents = ''
-            else:
+            if not self.check_mode or os.path.exists(local_path):
                 with open(local_path, 'rb') as f:
                     local_contents = f.read()
 

--- a/plugins/modules/lambda.py
+++ b/plugins/modules/lambda.py
@@ -168,6 +168,7 @@ lambda:
 
 import base64
 import hashlib
+import io
 import os
 import zipfile
 import time
@@ -187,10 +188,6 @@ from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (
     ec2_argument_spec,
     get_aws_connection_info,
     HAS_BOTO3,
-)
-
-from ansible.module_utils.six import (
-    BytesIO,
 )
 
 
@@ -339,7 +336,7 @@ class LambdaModule:
         return self.package
 
     def create_package(self, code):
-        data = BytesIO()
+        data = io.BytesIO()
         zip_info = zipfile.ZipInfo(
             'lambda_function.py',
             (1980, 1, 1, 0, 0, 0),

--- a/plugins/modules/lambda_alias.py
+++ b/plugins/modules/lambda_alias.py
@@ -2,6 +2,9 @@
 # Copyright (C) 2016 Matt Clay <matt@mystile.com>
 # GNU General Public License v3.0+ (see LICENSE.md or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from __future__ import annotations
+
+
 DOCUMENTATION = '''
 ---
 module: lambda_alias

--- a/plugins/modules/lambda_alias.py
+++ b/plugins/modules/lambda_alias.py
@@ -15,7 +15,6 @@ author:
     - Matt Clay (@mattclay) <matt@mystile.com>
 requirements:
     - boto3
-    - botocore
 options:
     function_name:
         description:
@@ -46,9 +45,6 @@ options:
             - The description of the alias.
         type: str
         default: ''
-extends_documentation_fragment:
-    - amazon.aws.common.modules
-    - amazon.aws.region.modules
 '''
 
 EXAMPLES = '''
@@ -61,36 +57,21 @@ lambda_alias:
     version: 3
 '''
 
-try:
-    import botocore
-    import botocore.exceptions
-except ImportError:
-    botocore = None
+from ..module_utils.aws import AwsModule
 
-from ansible.module_utils.basic import (
-    AnsibleModule,
-)
-
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (
-    boto3_conn,
-    camel_dict_to_snake_dict,
-    ec2_argument_spec,
-    get_aws_connection_info,
-    HAS_BOTO3,
-)
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         function_name=dict(required=True, type='str'),
         state=dict(required=False, default='present', type='str', choices=['present', 'absent']),
         version=dict(required=True, type='str'),
         name=dict(required=True, type='str'),
         description=dict(required=False, default='', type='str'),
-    ))
+    )
 
-    module = AnsibleModule(
+    module = AwsModule(
         argument_spec=argument_spec,
         supports_check_mode=True,
     )
@@ -106,25 +87,14 @@ def main():
 
 
 class LambdaAliasModule:
-    def __init__(self, module, check_mode, params):
+    def __init__(self, module: AwsModule, check_mode: bool, params: dict) -> None:
         self.module = module
         self.check_mode = check_mode
         self.params = params
-        self.al = None
-        self.sts = None
-        self.region = None
+        self.al = module.client.awslambda
+        self.region = module.region
 
     def run(self):
-        if not HAS_BOTO3:
-            return 'the boto3 python module is required to use this module', None, None
-
-        region, ec2_url, aws_connect_kwargs = get_aws_connection_info(self.module, boto3=True)
-
-        self.region = region
-
-        self.al = boto3_conn(self.module, conn_type='client', resource='lambda', region=region, endpoint=ec2_url, **aws_connect_kwargs)
-        self.sts = boto3_conn(self.module, conn_type='client', resource='sts', region=region, endpoint=ec2_url, **aws_connect_kwargs)
-
         choice_map = dict(
             present=self.alias_present,
             absent=self.alias_absent,
@@ -143,10 +113,8 @@ class LambdaAliasModule:
                 FunctionName=self.params['function_name'],
                 Name=self.params['name'],
             )
-        except botocore.exceptions.ClientError as ex:
-            if ex.response['Error']['Code'] == 'ResourceNotFoundException':
-                return None
-            raise
+        except self.al.exceptions.ResourceNotFoundException:
+            return None
 
     def alias_absent(self):
         raise Exception('FIXME: not implemented')
@@ -174,10 +142,7 @@ class LambdaAliasModule:
             else:
                 data = self.al.update_alias(**args)
         else:
-            caller_identity = self.sts.get_caller_identity()
-            caller_arn = caller_identity['Arn']
-
-            account_id = caller_arn.split(':')[4]
+            account_id = self.module.account_id
 
             arn = 'arn:aws:lambda:%s:%s:function:%s:%s' % (
                 self.region, account_id, self.params['function_name'], self.params['name'])

--- a/plugins/modules/lambda_layer.py
+++ b/plugins/modules/lambda_layer.py
@@ -2,6 +2,9 @@
 # Copyright (C) 2019 Matt Clay <matt@mystile.com>
 # GNU General Public License v3.0+ (see LICENSE.md or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from __future__ import annotations
+
+
 DOCUMENTATION = '''
 ---
 module: lambda_layer

--- a/plugins/modules/lambda_layer.py
+++ b/plugins/modules/lambda_layer.py
@@ -15,7 +15,6 @@ author:
     - Matt Clay (@mattclay) <matt@mystile.com>
 requirements:
     - boto3
-    - botocore
 options:
     name:
         description:
@@ -49,9 +48,6 @@ options:
             - absent
         default: present
         type: str
-extends_documentation_fragment:
-    - amazon.aws.common.modules
-    - amazon.aws.region.modules
 '''
 
 EXAMPLES = '''
@@ -70,33 +66,22 @@ import base64
 import hashlib
 import datetime
 
-from ansible.module_utils.basic import (
-    AnsibleModule,
-)
+from ..module_utils.aws import AwsModule
 
-from ansible.module_utils.common.dict_transformations import (
-    camel_dict_to_snake_dict,
-)
-
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (
-    boto3_conn,
-    ec2_argument_spec,
-    get_aws_connection_info,
-)
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         name=dict(type='str', required=True),
         description=dict(type='str'),
         compatible_runtimes=dict(type='list', elements='str'),
         path=dict(type='path', required=True),
         license_info=dict(type='str'),
         state=dict(default='present', type='str', choices=['present', 'absent']),
-    ))
+    )
 
-    module = AnsibleModule(
+    module = AwsModule(
         argument_spec=argument_spec,
         supports_check_mode=True,
     )
@@ -106,11 +91,11 @@ def main():
 
 
 class LambdaLayerModule:
-    def __init__(self, module, check_mode, params):
+    def __init__(self, module: AwsModule, check_mode: bool, params: dict) -> None:
         self.module = module
         self.check_mode = check_mode
         self.zip_file = None
-        self.lambda_client = None
+        self.lambda_client: LambdaClient | None = None
 
         self.name = params['name']
         self.description = params['description']
@@ -153,7 +138,7 @@ class LambdaLayerModule:
                 account_id = latest_layer_version['LayerVersionArn'].split(':')[4]
                 version = latest_layer_version['Version'] + 1
             else:
-                account_id = '0'  # this could be retrieved for a more accurate result in check mode
+                account_id = self.module.account_id
                 version = 1
 
             layer_arn = "arn:aws:lambda:%s:%s:layer:%s" % (self.lambda_client.region, account_id, self.name)
@@ -168,7 +153,7 @@ class LambdaLayerModule:
                 LayerArn=layer_arn,
                 LayerVersionArn=layer_version_arn,
                 Description=self.description,
-                CreatedDate=datetime.datetime.utcnow().isoformat(),  # close, but not exact, AWS returns "2019-03-30T08:52:06.009+0000"
+                CreatedDate=datetime.datetime.now(tz=datetime.timezone.utc).isoformat(),  # close, but not exact, AWS returns "2019-03-30T08:52:06.009+0000"
                 Version=version,
                 CompatibleRuntimes=self.compatible_runtimes,
                 LicenseInfo=self.license_info,
@@ -238,12 +223,10 @@ class LambdaLayerModule:
         return self.zip_file
 
 
-class LambdaClient(object):
-    def __init__(self, module):
-        region, endpoint, boto_params = get_aws_connection_info(module, boto3=True)
-
-        self.client = boto3_conn(module, conn_type='client', resource='lambda', region=region, endpoint=endpoint, **boto_params)
-        self.region = region
+class LambdaClient:
+    def __init__(self, module: AwsModule) -> None:
+        self.client = module.client.awslambda
+        self.region = module.region
 
     def publish_layer_version(self, layer_name, content, description, compatible_runtimes, license_info):
         """

--- a/plugins/modules/lambda_layer.py
+++ b/plugins/modules/lambda_layer.py
@@ -291,8 +291,7 @@ class LambdaClient:
 
             marker = response.get('NextMarker')
 
-            for layer_version in response['LayerVersions']:
-                yield layer_version
+            yield from response['LayerVersions']
 
             if not marker:
                 break

--- a/plugins/modules/lambda_package.py
+++ b/plugins/modules/lambda_package.py
@@ -50,13 +50,10 @@ lambda_package:
 '''
 
 import errno
+import io
 import os
 import zipfile
 import fnmatch
-
-from ansible.module_utils.six import (
-    BytesIO,
-)
 
 from ansible.module_utils.basic import (
     AnsibleModule,
@@ -139,7 +136,7 @@ class LambdaPackageModule:
                 paths.append((dst_path, src_path))
 
         paths = sorted(paths)
-        data = BytesIO()
+        data = io.BytesIO()
 
         with zipfile.ZipFile(data, 'w', zipfile.ZIP_DEFLATED) as zip_file:
             for dst_path, src_path in paths:

--- a/plugins/modules/lambda_package.py
+++ b/plugins/modules/lambda_package.py
@@ -80,8 +80,8 @@ class LambdaPackageModule:
     def __init__(self, module: AnsibleModule, check_mode: bool, params: dict) -> None:
         self.module = module
         self.check_mode = check_mode
-        self.src = params['src']
-        self.dest = params['dest']
+        self.src: str = params['src']
+        self.dest: str = params['dest']
         self.include = params['include']
         self.exclude = params['exclude']
         self.rename = params['rename'] or {}

--- a/plugins/modules/lambda_package.py
+++ b/plugins/modules/lambda_package.py
@@ -2,6 +2,9 @@
 # Copyright (C) 2019 Matt Clay <matt@mystile.com>
 # GNU General Public License v3.0+ (see LICENSE.md or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from __future__ import annotations
+
+
 DOCUMENTATION = '''
 ---
 module: lambda_package

--- a/plugins/modules/lambda_package.py
+++ b/plugins/modules/lambda_package.py
@@ -13,9 +13,6 @@ description:
     - Package files in a ZIP archive for deployment as Lambda functions.
 author:
     - Matt Clay (@mattclay) <matt@mystile.com>
-requirements:
-    - boto3
-    - botocore
 options:
     src:
         description:
@@ -58,9 +55,7 @@ import os
 import zipfile
 import fnmatch
 
-from ansible.module_utils.basic import (
-    AnsibleModule,
-)
+from ansible.module_utils.basic import AnsibleModule
 
 
 def main():
@@ -82,7 +77,7 @@ def main():
 
 
 class LambdaPackageModule:
-    def __init__(self, module, check_mode, params):
+    def __init__(self, module: AnsibleModule, check_mode: bool, params: dict) -> None:
         self.module = module
         self.check_mode = check_mode
         self.src = params['src']

--- a/plugins/modules/lambda_policy.py
+++ b/plugins/modules/lambda_policy.py
@@ -15,7 +15,6 @@ author:
     - Matt Clay (@mattclay) <matt@mystile.com>
 requirements:
     - boto3
-    - botocore
 options:
     function_name:
         description:
@@ -47,9 +46,6 @@ options:
             - The service that will invoke the function.
         required: true
         type: str
-extends_documentation_fragment:
-    - amazon.aws.common.modules
-    - amazon.aws.region.modules
 '''
 
 EXAMPLES = '''
@@ -63,36 +59,21 @@ lambda_policy:
 import json
 import uuid
 
-try:
-    import botocore
-    import botocore.exceptions
-except ImportError:
-    botocore = None
+from ..module_utils.aws import AwsModule
 
-from ansible.module_utils.basic import (
-    AnsibleModule,
-)
-
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (
-    boto3_conn,
-    camel_dict_to_snake_dict,
-    ec2_argument_spec,
-    get_aws_connection_info,
-    HAS_BOTO3,
-)
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         function_name=dict(required=True, type='str', aliases=['name']),
         state=dict(required=False, default='present', type='str', choices=['present', 'absent']),
         source_arn=dict(required=True, type='str'),
         qualifier=dict(required=False, default=None, type='str'),
         principal_service=dict(required=True, type='str'),
-    ))
+    )
 
-    module = AnsibleModule(
+    module = AwsModule(
         argument_spec=argument_spec,
         supports_check_mode=True,
     )
@@ -108,29 +89,17 @@ def main():
 
 
 class LambdaPolicyModule:
-    def __init__(self, module, check_mode, params):
+    def __init__(self, module: AwsModule, check_mode: bool, params: dict) -> None:
         self.module = module
         self.check_mode = check_mode
         self.params = params
-        self.al = None
-        self.iam = None
-        self.account_id = None
+        self.al = module.client.awslambda
 
     def run(self):
-        if not HAS_BOTO3:
-            return 'the boto3 python module is required to use this module', None, None
+        region = self.module.region
+        account_id = self.module.account_id
 
-        region, ec2_url, aws_connect_kwargs = get_aws_connection_info(self.module, boto3=True)
-
-        self.al = boto3_conn(self.module, conn_type='client', resource='lambda', region=region, endpoint=ec2_url,
-                             **aws_connect_kwargs)
-
-        self.iam = boto3_conn(self.module, conn_type='resource', resource='iam', region=region, endpoint=ec2_url,
-                              **aws_connect_kwargs)
-
-        self.account_id = self.iam.CurrentUser().arn.split(':')[4]
-
-        self.params['function_arn'] = 'arn:aws:lambda:%s:%s:function:%s' % (region, self.account_id, self.params['function_name'])
+        self.params['function_arn'] = 'arn:aws:lambda:%s:%s:function:%s' % (region, account_id, self.params['function_name'])
 
         if self.params['qualifier']:
             self.params['function_arn'] += ':%s' % self.params['qualifier']
@@ -174,10 +143,8 @@ class LambdaPolicyModule:
             )
             policy = json.loads(result['Policy'])
             return policy['Statement']
-        except botocore.exceptions.ClientError as ex:
-            if ex.response['Error']['Code'] == 'ResourceNotFoundException':
-                return []
-            raise
+        except self.al.exceptions.ResourceNotFoundException:
+            return []
 
     def create_permission(self):
         args = dict(

--- a/plugins/modules/lambda_policy.py
+++ b/plugins/modules/lambda_policy.py
@@ -2,6 +2,9 @@
 # Copyright (C) 2016 Matt Clay <matt@mystile.com>
 # GNU General Public License v3.0+ (see LICENSE.md or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from __future__ import annotations
+
+
 DOCUMENTATION = '''
 ---
 module: lambda_policy

--- a/plugins/modules/sqs_event.py
+++ b/plugins/modules/sqs_event.py
@@ -39,9 +39,6 @@ options:
             - absent
         default: present
         type: str
-extends_documentation_fragment:
-    - amazon.aws.common.modules
-    - amazon.aws.region.modules
 '''
 
 EXAMPLES = '''
@@ -53,34 +50,18 @@ sqs_event:
 
 import time
 
-try:
-    import botocore.exceptions
-except ImportError:
-    botocore = None
-
-from ansible.module_utils.basic import (
-    AnsibleModule,
-    missing_required_lib,
-)
-
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (
-    HAS_BOTO3,
-    boto3_conn,
-    ec2_argument_spec,
-    get_aws_connection_info,
-)
+from ..module_utils.aws import AwsModule
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         source_arn=dict(type='str', required=True),
         function_arn=dict(type='str'),
         batch_size=dict(type='int', default=1),
         state=dict(required=False, default='present', type='str', choices=['present', 'absent']),
-    ))
+    )
 
-    module = AnsibleModule(
+    module = AwsModule(
         argument_spec=argument_spec,
         supports_check_mode=True,
         required_if=[
@@ -90,12 +71,7 @@ def main():
         ],
     )
 
-    if not HAS_BOTO3:
-        module.fail_json(msg=missing_required_lib('boto3'))
-
-    region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
-
-    lambda_client = boto3_conn(module, conn_type='client', resource='lambda', region=region, endpoint=ec2_url, **aws_connect_kwargs)
+    lambda_client = module.client.awslambda
 
     source_arn = module.params['source_arn']
     function_arn = module.params['function_arn']
@@ -131,10 +107,7 @@ def main():
             try:
                 wait_until_ready(lambda_client, mapping)
                 changed = True
-            except botocore.exceptions.ClientError as ex:
-                if ex.response['Error']['Code'] != 'ResourceNotFoundException':
-                    raise
-
+            except lambda_client.exceptions.ResourceNotFoundException:
                 changed = False
 
             if changed and not module.check_mode:

--- a/plugins/modules/sqs_event.py
+++ b/plugins/modules/sqs_event.py
@@ -2,6 +2,9 @@
 # Copyright (C) 2021 Matt Clay <matt@mystile.com>
 # GNU General Public License v3.0+ (see LICENSE.md or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from __future__ import annotations
+
+
 DOCUMENTATION = '''
 ---
 module: sqs_event

--- a/plugins/modules/sqs_fifo_queue.py
+++ b/plugins/modules/sqs_fifo_queue.py
@@ -38,9 +38,6 @@ options:
             - absent
         default: present
         type: str
-extends_documentation_fragment:
-    - amazon.aws.common.modules
-    - amazon.aws.region.modules
 '''
 
 EXAMPLES = '''
@@ -50,29 +47,18 @@ sqs_fifo_queue:
     visibility_timeout: 30
 '''
 
-from ansible.module_utils.basic import (
-    AnsibleModule,
-    missing_required_lib,
-)
-
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (
-    HAS_BOTO3,
-    boto3_conn,
-    ec2_argument_spec,
-    get_aws_connection_info,
-)
+from ..module_utils.aws import AwsModule
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         name=dict(type='str', required=True),
         message_retention_period=dict(type='int'),
         visibility_timeout=dict(type='int'),
         state=dict(required=False, default='present', type='str', choices=['present', 'absent']),
-    ))
+    )
 
-    module = AnsibleModule(
+    module = AwsModule(
         argument_spec=argument_spec,
         supports_check_mode=True,
         required_if=[
@@ -83,12 +69,7 @@ def main():
         ],
     )
 
-    if not HAS_BOTO3:
-        module.fail_json(msg=missing_required_lib('boto3'))
-
-    region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
-
-    sqs_resource = boto3_conn(module, conn_type='resource', resource='sqs', region=region, endpoint=ec2_url, **aws_connect_kwargs)
+    sqs_resource = module.resource.sqs
 
     queue_name = module.params['name']
     state = module.params['state']

--- a/plugins/modules/sqs_fifo_queue.py
+++ b/plugins/modules/sqs_fifo_queue.py
@@ -2,6 +2,9 @@
 # Copyright (C) 2021 Matt Clay <matt@mystile.com>
 # GNU General Public License v3.0+ (see LICENSE.md or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from __future__ import annotations
+
+
 DOCUMENTATION = '''
 ---
 module: sqs_fifo_queue

--- a/tests/integration/targets/aws_account_facts/tasks/main.yml
+++ b/tests/integration/targets/aws_account_facts/tasks/main.yml
@@ -1,8 +1,7 @@
 - block:
     - import_tasks: tests.yml
-  module_defaults:
-    group/mattclay.aws.common:
-      access_key: "{{ aws_access_key }}"
-      secret_key: "{{ aws_secret_key }}"
-      aws_region: "{{ aws_region }}"
-      security_token: "{{ security_token }}"
+  environment:
+    AWS_ACCESS_KEY_ID: "{{ aws_access_key }}"
+    AWS_SECRET_ACCESS_KEY: "{{ aws_secret_key }}"
+    AWS_DEFAULT_REGION: "{{ aws_region }}"
+    AWS_SESSION_TOKEN: "{{ security_token }}"

--- a/tests/integration/targets/aws_availability_zone_facts/tasks/main.yml
+++ b/tests/integration/targets/aws_availability_zone_facts/tasks/main.yml
@@ -1,8 +1,7 @@
 - block:
     - import_tasks: tests.yml
-  module_defaults:
-    group/mattclay.aws.common:
-      access_key: "{{ aws_access_key }}"
-      secret_key: "{{ aws_secret_key }}"
-      aws_region: "{{ aws_region }}"
-      security_token: "{{ security_token }}"
+  environment:
+    AWS_ACCESS_KEY_ID: "{{ aws_access_key }}"
+    AWS_SECRET_ACCESS_KEY: "{{ aws_secret_key }}"
+    AWS_DEFAULT_REGION: "{{ aws_region }}"
+    AWS_SESSION_TOKEN: "{{ security_token }}"

--- a/tests/integration/targets/lambda/tasks/main.yml
+++ b/tests/integration/targets/lambda/tasks/main.yml
@@ -1,9 +1,8 @@
 - block:
     - import_tasks: setup.yml
     - import_tasks: tests.yml
-  module_defaults:
-    group/mattclay.aws.common:
-      access_key: "{{ aws_access_key }}"
-      secret_key: "{{ aws_secret_key }}"
-      aws_region: "{{ aws_region }}"
-      security_token: "{{ security_token }}"
+  environment:
+    AWS_ACCESS_KEY_ID: "{{ aws_access_key }}"
+    AWS_SECRET_ACCESS_KEY: "{{ aws_secret_key }}"
+    AWS_DEFAULT_REGION: "{{ aws_region }}"
+    AWS_SESSION_TOKEN: "{{ security_token }}"

--- a/tests/integration/targets/lambda_alias/tasks/main.yml
+++ b/tests/integration/targets/lambda_alias/tasks/main.yml
@@ -1,9 +1,8 @@
 - block:
     - import_tasks: setup.yml
     - import_tasks: tests.yml
-  module_defaults:
-    group/mattclay.aws.common:
-      access_key: "{{ aws_access_key }}"
-      secret_key: "{{ aws_secret_key }}"
-      aws_region: "{{ aws_region }}"
-      security_token: "{{ security_token }}"
+  environment:
+    AWS_ACCESS_KEY_ID: "{{ aws_access_key }}"
+    AWS_SECRET_ACCESS_KEY: "{{ aws_secret_key }}"
+    AWS_DEFAULT_REGION: "{{ aws_region }}"
+    AWS_SESSION_TOKEN: "{{ security_token }}"

--- a/tests/integration/targets/sqs_event/tasks/main.yml
+++ b/tests/integration/targets/sqs_event/tasks/main.yml
@@ -1,9 +1,8 @@
 - block:
     - import_tasks: setup.yml
     - import_tasks: tests.yml
-  module_defaults:
-    group/mattclay.aws.common:
-      access_key: "{{ aws_access_key }}"
-      secret_key: "{{ aws_secret_key }}"
-      aws_region: "{{ aws_region }}"
-      security_token: "{{ security_token }}"
+  environment:
+    AWS_ACCESS_KEY_ID: "{{ aws_access_key }}"
+    AWS_SECRET_ACCESS_KEY: "{{ aws_secret_key }}"
+    AWS_DEFAULT_REGION: "{{ aws_region }}"
+    AWS_SESSION_TOKEN: "{{ security_token }}"

--- a/tests/integration/targets/sqs_fifo_queue/tasks/main.yml
+++ b/tests/integration/targets/sqs_fifo_queue/tasks/main.yml
@@ -1,8 +1,7 @@
 - block:
     - import_tasks: tests.yml
-  module_defaults:
-    group/mattclay.aws.common:
-      access_key: "{{ aws_access_key }}"
-      secret_key: "{{ aws_secret_key }}"
-      aws_region: "{{ aws_region }}"
-      security_token: "{{ security_token }}"
+  environment:
+    AWS_ACCESS_KEY_ID: "{{ aws_access_key }}"
+    AWS_SECRET_ACCESS_KEY: "{{ aws_secret_key }}"
+    AWS_DEFAULT_REGION: "{{ aws_region }}"
+    AWS_SESSION_TOKEN: "{{ security_token }}"

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,2 @@
 ansible-core==2.16.5
-distlib==0.3.8
+distlib==0.4.0

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,2 @@
-ansible-core==2.16.5
+ansible-core==2.18.10
 distlib==0.4.0

--- a/tests/requirements.yml
+++ b/tests/requirements.yml
@@ -1,3 +1,3 @@
 collections:
-  - name: amazon.aws
-    version: '>=7.0.0,<8.0.0'
+  - name: amazon.aws  # used only for integration tests
+    version: '10.1.2'


### PR DESCRIPTION
* Remove use of six
* Fix typo
* Code modernization
  * Add `__future__` imports
  * Remove Python 2 compat
* Remove amazon.aws dependency (except for testing)
  * Breaking Change - Modules no longer accept connection details as module arguments. Standard boto3 environment variables and configuration files must be used instead. This was done to simplify the codebase and ease upgrades.
  * The collection is no longer dependent on amazon.aws, making it easier to update each one independently.
* Update distlib requirement
* Remove action_group definition
* Test against ansible-core 2.18
* Fix pylint issue
* Update amazon.aws version used in integration tests
* Avoid static analysis issue in PyCharm
* Add missing type annotations
* Update to version 5.0.0